### PR TITLE
Faster GQT

### DIFF
--- a/gqt/gqt_suite_test.go
+++ b/gqt/gqt_suite_test.go
@@ -1,6 +1,7 @@
 package gqt_test
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"time"
@@ -27,10 +28,6 @@ func TestGqt(t *testing.T) {
 
 	BeforeEach(func() {
 		if OciRuntimeBin == "" {
-			OciRuntimeBin = defaultRuntime[runtime.GOOS]
-		}
-
-		if OciRuntimeBin == "" {
 			Skip("No OCI Runtime for Platform: " + runtime.GOOS)
 		}
 	})
@@ -39,12 +36,29 @@ func TestGqt(t *testing.T) {
 	RunSpecs(t, "GQT Suite")
 }
 
+var gardenBin, iodaemonBin string
+
+var _ = BeforeSuite(func() {
+	if OciRuntimeBin == "" {
+		OciRuntimeBin = defaultRuntime[runtime.GOOS]
+	}
+
+	if OciRuntimeBin == "" {
+		fmt.Fprintf(GinkgoWriter, "Skipping GQT BeforeSuite, no OCI runtime for %q\n", runtime.GOOS)
+		return
+	}
+
+	var err error
+	gardenBin, err = gexec.Build("github.com/cloudfoundry-incubator/guardian/cmd/guardian", "-tags", "daemon")
+	Expect(err).NotTo(HaveOccurred())
+	iodaemonBin, err = gexec.Build("github.com/cloudfoundry-incubator/guardian/rundmc/iodaemon/cmd/iodaemon")
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	gexec.CleanupBuildArtifacts()
+})
+
 func startGarden(argv ...string) *runner.RunningGarden {
-	gardenBin, err := gexec.Build("github.com/cloudfoundry-incubator/guardian/cmd/guardian", "-tags", "daemon")
-	Expect(err).NotTo(HaveOccurred())
-
-	iodaemonBin, err := gexec.Build("github.com/cloudfoundry-incubator/guardian/rundmc/iodaemon/cmd/iodaemon")
-	Expect(err).NotTo(HaveOccurred())
-
 	return runner.Start(gardenBin, iodaemonBin, argv...)
 }


### PR DESCRIPTION
GQT suite builds binaries only once, when the suite starts, instead of before every `It`

Context:
In testing guardian on Go 1.5, we found that the GQT suite was very slow.  Most of that seems to be due to compilation time in `startGuardian` which is called in the `BeforeEach` of every spec.

With this change the GQT suite runtime drops from about 2 minutes to less than 1 (on our AWS m4.large).

cc: @zachgersh 