### PR TITLE
Use ducati constructor

### DIFF
--- a/cmd/guardian/main.go
+++ b/cmd/guardian/main.go
@@ -369,8 +369,12 @@ func wireNetworker(log lager.Logger, tag string, networkPoolCIDR *net.IPNet, ext
 			portPool,
 		)
 	case "ducati":
+		d, err := ducati.New()
+		if err != nil {
+			panic(err)
+		}
 		return gardener.ForeignNetworkAdaptor{
-			ForeignNetworker: &ducati.Ducati{},
+			ForeignNetworker: d,
 		}
 	default:
 		log.Fatal("failed-to-select-network-module", fmt.Errorf("unknown network module %q", networkModule))

--- a/cmd/guardian/main.go
+++ b/cmd/guardian/main.go
@@ -371,7 +371,7 @@ func wireNetworker(log lager.Logger, tag string, networkPoolCIDR *net.IPNet, ext
 	case "ducati":
 		d, err := ducati.New()
 		if err != nil {
-			panic(err)
+			log.Fatal("failed-to-initialize-ducati-network-module", err)
 		}
 		return gardener.ForeignNetworkAdaptor{
 			ForeignNetworker: d,

--- a/gqt/gqt_suite_test.go
+++ b/gqt/gqt_suite_test.go
@@ -37,6 +37,7 @@ func TestGqt(t *testing.T) {
 		}
 
 		if bins["oci_runtime_path"] != "" {
+			os.Setenv("GO15VENDOREXPERIMENT", "1")
 			bins["garden_bin_path"], err = gexec.Build("github.com/cloudfoundry-incubator/guardian/cmd/guardian", "-tags", "daemon")
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
This requires a submodule update for ducati to get the `New()` method.

Pulling this wil bring in libnetwork via ducati's vendor directory.

Acceptance tests now use go 1.5's vendoring experiment.