### PR TITLE
Revert "Use ducati constructor"

### DIFF
--- a/cmd/guardian/main.go
+++ b/cmd/guardian/main.go
@@ -378,12 +378,8 @@ func wireNetworker(
 			portPool,
 		)
 	case "ducati":
-		d, err := ducati.New()
-		if err != nil {
-			log.Fatal("failed-to-initialize-ducati-network-module", err)
-		}
 		return gardener.ForeignNetworkAdaptor{
-			ForeignNetworker: d,
+			ForeignNetworker: &ducati.Ducati{},
 		}
 	default:
 		log.Fatal("failed-to-select-network-module", fmt.Errorf("unknown network module %q", networkModule))

--- a/gqt/gqt_suite_test.go
+++ b/gqt/gqt_suite_test.go
@@ -37,7 +37,6 @@ func TestGqt(t *testing.T) {
 		}
 
 		if bins["oci_runtime_path"] != "" {
-			os.Setenv("GO15VENDOREXPERIMENT", "1")
 			bins["garden_bin_path"], err = gexec.Build("github.com/cloudfoundry-incubator/guardian/cmd/guardian", "-tags", "daemon")
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Reverts cloudfoundry-incubator/guardian#13.

I tried making `vendor` and `Gosub` work, but it turns out it is not very simple. I fixed the compilation issues for nested tests (GATS and GQT) but not the BOSH release. 

We are using the script `scripts/sync-package-specs` that generates the `guardian` BOSH package specs. Unfortunately, this relies heavily on `gosub`. Gosub is misinterpreting the `ducati/vendor/` directory contents (`libnetwork` currently) as gosub dependencies. This leads to an undeployable BOSH release.

We need to think about this and either adopt a different approach for the Ducati dependency management, or fix Gosub (which might be simpler). But unfortunately, I have to revert this PR to fix the CI :(