### PR TITLE
Replace direct reference to ducati with new GEN Client

### DIFF
--- a/gqt/gqt_suite_test.go
+++ b/gqt/gqt_suite_test.go
@@ -76,8 +76,8 @@ func TestGqt(t *testing.T) {
 }
 
 func startGarden(argv ...string) *runner.RunningGarden {
-	if networkModule := os.Getenv("NETWORK_MODULE"); networkModule != "" {
-		argv = append(argv, "--networkModule="+networkModule)
+	if networkModulePath := os.Getenv("NETWORK_MODULE_PATH"); networkModulePath != "" {
+		argv = append(argv, "--networkModulePath="+networkModulePath)
 	}
 
 	return runner.Start(gardenBin, iodaemonBin, nstarBin, argv...)


### PR DESCRIPTION
Hey there.

Here's an attempt at implementing the external client behavior we discussed on Tuesday. 

Highlights:
- [Ducati](https://github.com/cloudfoundry-incubator/ducati) has turned into a standalone binary, which accepts a rudimentary form of RPC via JSON on `stdin`/`stdout`.  It also has its [own BOSH release](https://github.com/cloudfoundry-incubator/ducati-release).
- Guardian no longer depends on Ducati.  Instead...
- Guardian now interacts with Ducati via a new [Guardian External Networker (GEN) Client](https://github.com/cloudfoundry-incubator/genclient).  This is a work-in-progress, thin Go client for an
  external networker.
- The Guardian command line flag to use this stuff changes to `networkModulePath`
  - default value is empty string, means use Kawasaki
  - otherwise the string is interpreted as a filesystem path to external networker binary, passed to the GEN Client.

I think this approach achieves the big picture goals:
- You can modify your `gardner.Networker` interface without waiting for us to make a change.  Your `gardener.ForeignNetworkAdaptor` is unchanged, so just add & edit its stubs as you need.
- Your team doesn't need to think about the inter-process communication mechanism, since it is in a separate, external library (`genclient`) that our team will own (until you want to take it over).
- Our team can vendor, package, and release our own way, without it impacting your team

Some technical points when bumping Guardian Release:
- Add the new submodule: https://github.com/cloudfoundry-incubator/genclient
- Remove the old `ducati` submodule -- no more vendor experiment!
- [Update the name of the parameter in the Concourse task](https://github.com/zachgersh/guardian-release/commit/6087f3b0a14d150f5946cd25444fa2cb8e77a9ea)

Going forward, the flow for our team to reach feature-parity to Kawasaki will look like:

1. add a feature to Ducati
2. add the method signature to `genclient`
3. send you guys a small PR to `gardener.ForeignNetworkAdaptor` that simply removes the stub for that method.

Thoughts?

Ref: [Tracker #111077494](https://www.pivotaltracker.com/story/show/111077494)

CC: @cloudfoundry-incubator/container-networking 