### PR TITLE
Support using custom DNS servers instead of picking from the host

### DIFF
--- a/cmd/kawasaki/main.go
+++ b/cmd/kawasaki/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cloudfoundry-incubator/guardian/kawasaki/dns"
 	"github.com/cloudfoundry-incubator/guardian/kawasaki/factory"
 	"github.com/cloudfoundry-incubator/guardian/kawasaki/iptables"
+	"github.com/cloudfoundry-incubator/guardian/pkg/vars"
 	"github.com/cloudfoundry/gunk/command_runner/linux_command_runner"
 	"github.com/opencontainers/specs"
 	"github.com/pivotal-golang/lager"
@@ -54,6 +55,7 @@ func main() {
 	flag.Var(&IPValue{&config.BridgeIP}, "bridge-ip", "the IP address of the bridge interface")
 	flag.Var(&IPValue{&config.ExternalIP}, "external-ip", "the IP address of the host interface")
 	flag.Var(&IPValue{&config.ContainerIP}, "container-ip", "the IP address of the container interface")
+	flag.Var(&vars.IPList{List: &config.DNSServers}, "dns-server", "the IP address(s) of DNS servers to unconditionally use")
 	subnet := flag.String("subnet", "", "subnet of the bridge")
 	flag.Parse()
 
@@ -117,6 +119,7 @@ func wireDNSResolvConfigurer(state specs.State, config kawasaki.NetworkConfig) *
 		ResolvFileCompiler: &dns.ResolvFileCompiler{
 			HostResolvConfPath: "/etc/resolv.conf",
 			HostIP:             config.BridgeIP,
+			OverrideServers:    config.DNSServers,
 		},
 		FileWriter: &dns.RootfsWriter{
 			RootfsPath: bndl.Spec.Spec.Root.Path,

--- a/kawasaki/config_creator.go
+++ b/kawasaki/config_creator.go
@@ -31,6 +31,7 @@ type NetworkConfig struct {
 	ExternalIP      net.IP
 	Subnet          *net.IPNet
 	Mtu             int
+	DNSServers      []net.IP
 }
 
 type Creator struct {
@@ -38,9 +39,10 @@ type Creator struct {
 	interfacePrefix string
 	chainPrefix     string
 	externalIP      net.IP
+	dnsServers      []net.IP
 }
 
-func NewConfigCreator(idGenerator IDGenerator, interfacePrefix, chainPrefix string, externalIP net.IP) *Creator {
+func NewConfigCreator(idGenerator IDGenerator, interfacePrefix, chainPrefix string, externalIP net.IP, dnsServers []net.IP) *Creator {
 	if len(interfacePrefix) > maxInterfacePrefixLen {
 		panic("interface prefix is too long")
 	}
@@ -54,6 +56,7 @@ func NewConfigCreator(idGenerator IDGenerator, interfacePrefix, chainPrefix stri
 		interfacePrefix: interfacePrefix,
 		chainPrefix:     chainPrefix,
 		externalIP:      externalIP,
+		dnsServers:      dnsServers,
 	}
 }
 
@@ -70,5 +73,6 @@ func (c *Creator) Create(log lager.Logger, handle string, subnet *net.IPNet, ip 
 		ExternalIP:      c.externalIP,
 		Subnet:          subnet,
 		Mtu:             1500,
+		DNSServers:      c.dnsServers,
 	}, nil
 }

--- a/kawasaki/dns/resolv_file_compiler.go
+++ b/kawasaki/dns/resolv_file_compiler.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -13,12 +14,14 @@ import (
 type ResolvFileCompiler struct {
 	HostResolvConfPath string
 	HostIP             net.IP
+	OverrideServers    []net.IP
 }
 
 func (r *ResolvFileCompiler) Compile(log lager.Logger) ([]byte, error) {
 	log = log.Session("resolv-file-compile", lager.Data{
 		"HostResolvConfPath": r.HostResolvConfPath,
 		"HostIP":             r.HostIP,
+		"OverrideServers":    r.OverrideServers,
 	})
 
 	f, err := os.Open(r.HostResolvConfPath)
@@ -32,6 +35,14 @@ func (r *ResolvFileCompiler) Compile(log lager.Logger) ([]byte, error) {
 	if err != nil {
 		log.Error("reading-host-resolv-conf", err)
 		return nil, fmt.Errorf("reading file '%s': %s", r.HostResolvConfPath, err)
+	}
+
+	if len(r.OverrideServers) > 0 {
+		var buf bytes.Buffer
+		for _, name := range r.OverrideServers {
+			fmt.Fprintf(&buf, "nameserver %s\n", name.String())
+		}
+		return buf.Bytes(), nil
 	}
 
 	matches, err := regexp.Match(`^\s*nameserver\s+127\.0\.0\.1\s*$`, contents)

--- a/kawasaki/dns/resolv_file_compiler_test.go
+++ b/kawasaki/dns/resolv_file_compiler_test.go
@@ -63,6 +63,21 @@ var _ = Describe("ResolvFileCompiler", func() {
 			Expect(os.Remove(hostResolvConfPath)).To(Succeed())
 		})
 
+		Context("and explicit overrides are given", func() {
+			It("should make the container use given DNS servers", func() {
+				compiler.OverrideServers = []net.IP{
+					net.ParseIP("8.8.8.8"),
+					net.ParseIP("8.8.4.4"),
+				}
+
+				Expect(compiler.OverrideServers).NotTo(BeEmpty())
+				contents, err := compiler.Compile(log)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(string(contents)).To(Equal("nameserver 8.8.8.8\nnameserver 8.8.4.4\n"))
+			})
+		})
+
 		Context("and the host is running DNS", func() {
 			BeforeEach(func() {
 				writeFile(hostResolvConfPath, "nameserver 127.0.0.1\n")

--- a/kawasaki/networker_test.go
+++ b/kawasaki/networker_test.go
@@ -70,6 +70,10 @@ var _ = Describe("Networker", func() {
 			ExternalIP:      net.ParseIP("128.128.90.90"),
 			Subnet:          subnet,
 			Mtu:             1200,
+			DNSServers: []net.IP{
+				net.ParseIP("8.8.8.8"),
+				net.ParseIP("8.8.4.4"),
+			},
 		}
 
 		fakeConfigCreator.CreateReturns(networkConfig, nil)
@@ -85,6 +89,7 @@ var _ = Describe("Networker", func() {
 			"kawasaki.iptable-prefix":      networkConfig.IPTablePrefix,
 			"kawasaki.iptable-inst":        networkConfig.IPTableInstance,
 			"kawasaki.mtu":                 strconv.Itoa(networkConfig.Mtu),
+			"kawasaki.dns-servers":         "8.8.8.8, 8.8.4.4",
 		}
 
 		fakeConfigStore.GetStub = func(handle, name string) (string, error) {
@@ -152,6 +157,7 @@ var _ = Describe("Networker", func() {
 			Expect(config["kawasaki.iptable-prefix"]).To(Equal(networkConfig.IPTablePrefix))
 			Expect(config["kawasaki.iptable-inst"]).To(Equal(networkConfig.IPTableInstance))
 			Expect(config["kawasaki.mtu"]).To(Equal(strconv.Itoa(networkConfig.Mtu)))
+			Expect(config["kawasaki.dns-servers"]).To(Equal("8.8.8.8, 8.8.4.4"))
 		})
 
 		Context("when the configuration can't be created", func() {
@@ -183,6 +189,9 @@ var _ = Describe("Networker", func() {
 			Expect(hooks.Prestart.Args).To(ContainElement("--iptable-instance=" + networkConfig.IPTableInstance))
 			Expect(hooks.Prestart.Args).To(ContainElement("--iptable-prefix=" + networkConfig.IPTablePrefix))
 			Expect(hooks.Prestart.Args).To(ContainElement("--mtu=" + strconv.Itoa(networkConfig.Mtu)))
+			for _, dnsServer := range networkConfig.DNSServers {
+				Expect(hooks.Prestart.Args).To(ContainElement("--dns-server=" + dnsServer.String()))
+			}
 		})
 	})
 

--- a/pkg/vars/vars.go
+++ b/pkg/vars/vars.go
@@ -1,6 +1,10 @@
 package vars
 
-import "strings"
+import (
+	"fmt"
+	"net"
+	"strings"
+)
 
 type StringList struct {
 	List []string
@@ -17,4 +21,26 @@ func (sl *StringList) String() string {
 
 func (sl StringList) Get() interface{} {
 	return sl.List
+}
+
+// IPList is a flag.Value to hold a list of IP addresses
+type IPList struct {
+	List *[]net.IP
+}
+
+func (l IPList) String() string {
+	var strs []string
+	for _, ip := range *l.List {
+		strs = append(strs, ip.String())
+	}
+	return strings.Join(strs, ", ")
+}
+
+func (l IPList) Set(s string) error {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return fmt.Errorf("'%s' is not a valid IP address", s)
+	}
+	*l.List = append(*l.List, ip)
+	return nil
 }

--- a/pkg/vars/vars_test.go
+++ b/pkg/vars/vars_test.go
@@ -1,32 +1,63 @@
 package vars_test
 
 import (
+	"net"
+
 	"github.com/cloudfoundry-incubator/guardian/pkg/vars"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Vars", func() {
-	Describe("when set is called", func() {
+	Describe("StringList", func() {
+		Describe("when set is called", func() {
 
-		var sl *vars.StringList
+			var sl *vars.StringList
 
-		BeforeEach(func() {
-			sl = &vars.StringList{}
-			Expect(sl.Set("foo")).To(Succeed())
-			Expect(sl.Set("bar")).To(Succeed())
+			BeforeEach(func() {
+				sl = &vars.StringList{}
+				Expect(sl.Set("foo")).To(Succeed())
+				Expect(sl.Set("bar")).To(Succeed())
+			})
+
+			It("adds the value to the list", func() {
+				Expect(sl.List).To(ConsistOf("foo", "bar"))
+			})
+
+			It("stringifies with commas", func() {
+				Expect(sl.String()).To(Equal("foo, bar"))
+			})
+
+			It("returns the list from Get()", func() {
+				Expect(sl.Get()).To(Equal([]string{"foo", "bar"}))
+			})
 		})
+	})
 
-		It("adds the value to the list", func() {
-			Expect(sl.List).To(ConsistOf("foo", "bar"))
-		})
+	Describe("IPList", func() {
+		Describe("when set is called", func() {
 
-		It("stringifies with commas", func() {
-			Expect(sl.String()).To(Equal("foo, bar"))
-		})
+			var ipl *vars.IPList
+			var ips []net.IP
 
-		It("returns the list from Get()", func() {
-			Expect(sl.Get()).To(Equal([]string{"foo", "bar"}))
+			BeforeEach(func() {
+				ips = nil
+				ipl = &vars.IPList{List: &ips}
+				Expect(ipl.Set("1.2.3.4")).To(Succeed())
+				Expect(ipl.Set("::1")).To(Succeed())
+			})
+
+			It("adds the value to the list", func() {
+				Expect(ips).To(ConsistOf(net.ParseIP("1.2.3.4"), net.ParseIP("::1")))
+			})
+
+			It("stringifies with commas", func() {
+				Expect(ipl.String()).To(Equal("1.2.3.4, ::1"))
+			})
+
+			It("rejects invalid addresses", func() {
+				Expect(ipl.Set("www.example.com")).To(MatchError("'www.example.com' is not a valid IP address"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
This implements a `-dnsServer` command line option (that may be given multiple times) which will force the container to use those DNS servers rather than guessing from the host's `resolv.conf`.

See also cloudfoundry-incubator/garden-linux#60.

This will have matching PRs in `garden` and `guardian-release`, followed by a second PR in the garden family to implement the same.