### PR TITLE
Make tests (vet/ginko) pass on Linux (outside of concourse)

### DIFF
--- a/kawasaki/configurer_test.go
+++ b/kawasaki/configurer_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Configurer", func() {
 
 				Expect(configurer.Apply(logger, cfg, netnsFD.Name())).To(Succeed())
 				command := fmt.Sprintf("lsof %s | wc -l", netnsFD.Name())
-				output, err := exec.Command("sh", "-c", command).CombinedOutput()
+				output, err := exec.Command("sh", "-c", command).Output()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(strings.TrimSpace(string(output))).To(Equal("2"))
 			})

--- a/kawasaki/devices/bridge_linux.go
+++ b/kawasaki/devices/bridge_linux.go
@@ -19,7 +19,7 @@ func (Bridge) Create(name string, ip net.IP, subnet *net.IPNet) (intf *net.Inter
 	netlinkMu.Lock()
 	defer netlinkMu.Unlock()
 
-	link := &netlink.Bridge{netlink.LinkAttrs{Name: name}}
+	link := &netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: name}}
 
 	if err := netlink.LinkAdd(link); err != nil && err.Error() != "file exists" {
 		return nil, fmt.Errorf("devices: create bridge: %v", err)
@@ -63,7 +63,7 @@ func (Bridge) Destroy(bridge string) error {
 
 	for _, i := range intfs {
 		if i.Name == bridge {
-			link := &netlink.Bridge{netlink.LinkAttrs{Name: bridge}}
+			link := &netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: bridge}}
 			return netlink.LinkDel(link)
 		}
 	}

--- a/kawasaki/devices/devices_suite_test.go
+++ b/kawasaki/devices/devices_suite_test.go
@@ -1,13 +1,20 @@
 package devices_test
 
 import (
+	"os/user"
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestDevices(t *testing.T) {
+	BeforeEach(func() {
+		if u, err := user.Current(); err == nil && u.Uid != "0" {
+			Skip("Devices suite requires root to run")
+		}
+	})
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Devices Suite")
 }

--- a/kawasaki/netns/netns_execer_linux_test.go
+++ b/kawasaki/netns/netns_execer_linux_test.go
@@ -35,7 +35,7 @@ var _ = Describe("NetnsExecerLinux", func() {
 
 			Expect(netns.Exec(fd, func() error {
 
-				link := &netlink.Bridge{netlink.LinkAttrs{Name: "banana-iface"}}
+				link := &netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: "banana-iface"}}
 				Expect(netlink.LinkAdd(link)).To(Succeed())
 
 				_, err := net.InterfaceByName("banana-iface")

--- a/kawasaki/netns/netns_suite_test.go
+++ b/kawasaki/netns/netns_suite_test.go
@@ -1,13 +1,20 @@
 package netns_test
 
 import (
+	"os/user"
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestNetns(t *testing.T) {
+	BeforeEach(func() {
+		if u, err := user.Current(); err == nil && u.Uid != "0" {
+			Skip("Netns suite requires root to run")
+		}
+	})
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Netns Suite")
 }


### PR DESCRIPTION
- `lsof` will warn if user is not root; ignore `stderr`
- devices + netns suites will fail if not root; ignore those suites in that case
- `go vet` wants keys for all fields (netlink.Bridge)