### PR TITLE
support direct rootfs usage via raw://

### DIFF
--- a/gardener/gardener.go
+++ b/gardener/gardener.go
@@ -21,6 +21,8 @@ const BridgeIPKey = "garden.network.host-ip"
 const ExternalIPKey = "garden.network.external-ip"
 const MappedPortsKey = "garden.network.mapped-ports"
 
+const RawRootFSScheme = "raw"
+
 type SysInfoProvider interface {
 	TotalMemory() (uint64, error)
 	TotalDisk() (uint64, error)
@@ -187,14 +189,22 @@ func (g *Gardener) Create(spec garden.ContainerSpec) (ctr garden.Container, err 
 		log.Error("graph-cleanup-failed", err)
 	}
 
-	rootFSPath, env, err := g.VolumeCreator.Create(log, spec.Handle, rootfs_provider.Spec{
-		RootFS:     rootFSURL,
-		QuotaSize:  int64(spec.Limits.Disk.ByteHard),
-		QuotaScope: spec.Limits.Disk.Scope,
-		Namespaced: !spec.Privileged,
-	})
-	if err != nil {
-		return nil, err
+	var rootFSPath string
+	var env []string
+
+	if rootFSURL.Scheme == RawRootFSScheme {
+		rootFSPath = rootFSURL.Path
+	} else {
+		var err error
+		rootFSPath, env, err = g.VolumeCreator.Create(log, spec.Handle, rootfs_provider.Spec{
+			RootFS:     rootFSURL,
+			QuotaSize:  int64(spec.Limits.Disk.ByteHard),
+			QuotaScope: spec.Limits.Disk.Scope,
+			Namespaced: !spec.Privileged,
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if err := g.Containerizer.Create(log, DesiredContainerSpec{

--- a/gardener/gardener_test.go
+++ b/gardener/gardener_test.go
@@ -212,6 +212,20 @@ var _ = Describe("Gardener", func() {
 				})
 			})
 
+			Context("when the rootfs path is raw", func() {
+				It("creates the container with the given path", func() {
+					_, err := gdnr.Create(garden.ContainerSpec{
+						Handle:     "bob",
+						RootFSPath: "raw:///banana",
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(containerizer.CreateCallCount()).To(Equal(1))
+					_, spec := containerizer.CreateArgsForCall(0)
+					Expect(spec.RootFSPath).To(Equal("/banana"))
+				})
+			})
+
 			It("passes the created rootfs to the containerizer", func() {
 				volumeCreator.CreateStub = func(_ lager.Logger, handle string, spec rootfs_provider.Spec) (string, []string, error) {
 					return "/path/to/rootfs/" + spec.RootFS.String() + "/" + handle, []string{}, nil


### PR DESCRIPTION
this circumvents the graph importing and layering, which is sometimes
redundant (e.g. in Concourse which uses baggageclaim for all rootfs
management)