### PR TITLE
more conservatively process /proc/cgroups

### DIFF
--- a/rundmc/starter.go
+++ b/rundmc/starter.go
@@ -18,6 +18,16 @@ type Starter struct {
 	*CgroupStarter
 }
 
+const cgroupsHeader = "#subsys_name hierarchy num_cgroups enabled"
+
+type CgroupsFormatError struct {
+	Content string
+}
+
+func (err CgroupsFormatError) Error() string {
+	return fmt.Sprintf("unknown /proc/cgroups format: %s", err.Content)
+}
+
 func NewStarter(logger lager.Logger, procCgroupReader io.ReadCloser, procSelfCgroupReader io.ReadCloser, cgroupMountpoint string, runner command_runner.CommandRunner) *Starter {
 	return &Starter{
 		&CgroupStarter{
@@ -44,7 +54,7 @@ func (s *CgroupStarter) Start() error {
 	return s.mountCgroupsIfNeeded(s.Logger)
 }
 
-func (s *CgroupStarter) mountCgroupsIfNeeded(log lager.Logger) error {
+func (s *CgroupStarter) mountCgroupsIfNeeded(logger lager.Logger) error {
 	defer s.ProcCgroups.Close()
 	defer s.ProcSelfCgroups.Close()
 	if err := os.MkdirAll(s.CgroupPath, 0755); err != nil {
@@ -52,9 +62,9 @@ func (s *CgroupStarter) mountCgroupsIfNeeded(log lager.Logger) error {
 	}
 
 	if !s.isMountPoint(s.CgroupPath) {
-		s.mountTmpfsOnCgroupPath(log, s.CgroupPath)
+		s.mountTmpfsOnCgroupPath(logger, s.CgroupPath)
 	} else {
-		log.Info("cgroups-tmpfs-already-mounted", lager.Data{"path": s.CgroupPath})
+		logger.Info("cgroups-tmpfs-already-mounted", lager.Data{"path": s.CgroupPath})
 	}
 
 	subsystemGroupings, err := s.subsystemGroupings()
@@ -64,18 +74,32 @@ func (s *CgroupStarter) mountCgroupsIfNeeded(log lager.Logger) error {
 
 	scanner := bufio.NewScanner(s.ProcCgroups)
 
-	scanner.Scan()
-	scanner.Scan() // ignore header
+	if !scanner.Scan() {
+		return CgroupsFormatError{Content: "(empty)"}
+	}
+
+	if _, err := fmt.Sscanf(scanner.Text(), cgroupsHeader); err != nil {
+		return CgroupsFormatError{Content: scanner.Text()}
+	}
 
 	for scanner.Scan() {
-		var cgroupInProcCgroups string
-		if n, err := fmt.Sscanf(scanner.Text(), "%s ", &cgroupInProcCgroups); err != nil || n != 1 {
+		var subsystem string
+		var skip, enabled int
+		n, err := fmt.Sscanf(scanner.Text(), "%s %d %d %d ", &subsystem, &skip, &skip, &enabled)
+		if err != nil || n != 4 {
+			return CgroupsFormatError{Content: scanner.Text()}
+		}
+
+		if enabled == 0 {
 			continue
 		}
 
-		cgroupsToMount := subsystemGroupings[cgroupInProcCgroups]
+		cgroupsToMount, found := subsystemGroupings[subsystem]
+		if !found {
+			cgroupsToMount = subsystem
+		}
 
-		if err := s.mountCgroup(log, path.Join(s.CgroupPath, cgroupInProcCgroups), cgroupsToMount); err != nil {
+		if err := s.mountCgroup(logger, path.Join(s.CgroupPath, subsystem), cgroupsToMount); err != nil {
 			return err
 		}
 	}
@@ -114,27 +138,29 @@ func (s *CgroupStarter) subsystemGroupings() (map[string]string, error) {
 	return groupings, scanner.Err()
 }
 
-func (s *CgroupStarter) mountCgroup(log lager.Logger, cgroupPath, subsystems string) error {
-	log = log.Session("mount-cgroup", lager.Data{
+func (s *CgroupStarter) mountCgroup(logger lager.Logger, cgroupPath, subsystems string) error {
+	logger = logger.Session("mount-cgroup", lager.Data{
 		"path":       cgroupPath,
 		"subsystems": subsystems,
 	})
 
-	log.Info("started")
+	logger.Info("started")
+
 	if !s.isMountPoint(cgroupPath) {
 		if err := os.MkdirAll(cgroupPath, 0755); err != nil {
 			return fmt.Errorf("mkdir '%s': %s", cgroupPath, err)
 		}
 
 		cmd := exec.Command("mount", "-n", "-t", "cgroup", "-o", subsystems, "cgroup", cgroupPath)
-		cmd.Stderr = logging.Writer(log.Session("mount-cgroup-cmd"))
+		cmd.Stderr = logging.Writer(logger.Session("mount-cgroup-cmd"))
 		if err := s.CommandRunner.Run(cmd); err != nil {
 			return fmt.Errorf("mounting subsystems '%s' in '%s': %s", subsystems, cgroupPath, err)
 		}
 	} else {
-		log.Info("subsystems-already-mounted")
+		logger.Info("subsystems-already-mounted")
 	}
-	log.Info("finished")
+
+	logger.Info("finished")
 
 	return nil
 }

--- a/rundmc/starter_test.go
+++ b/rundmc/starter_test.go
@@ -84,63 +84,189 @@ var _ = Describe("CgroupStarter", func() {
 		})
 	})
 
-	Context("when the ProcCgroup reader contains entries (after the header), and ProcSelfCgroup reader contains the mount scheme", func() {
+	Context("with a sane /proc/cgroups and /proc/self/cgroup", func() {
 		BeforeEach(func() {
-			procCgroups.Write([]byte(
-				`header header header
----- ---- ----
-devices blah blah
-memory lala la
-cpu trala la
-cpuacct blahdy blah
-`))
+			_, err := procCgroups.Write([]byte(
+				"#subsys_name\thierarchy\tnum_cgroups\tenabled\n" +
+					"devices\t1\t1\t1\n" +
+					"memory\t2\t1\t1\n" +
+					"cpu\t3\t1\t1\n" +
+					"cpuacct\t4\t1\t1\n",
+			))
+			Expect(err).NotTo(HaveOccurred())
 
-			procSelfCgroups.Write([]byte(
-				`5:devices:/
-4:memory:/
-3:cpu,cpuacct:/
-`))
+			_, err = procSelfCgroups.Write([]byte(
+				"5:devices:/\n" +
+					"4:memory:/\n" +
+					"3:cpu,cpuacct:/\n",
+			))
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, notMounted := range []string{"devices", "cpu", "cpuacct"} {
+				runner.WhenRunning(fake_command_runner.CommandSpec{
+					Path: "mountpoint",
+					Args: []string{"-q", path.Join(tmpDir, "cgroup", notMounted)},
+				}, func(cmd *exec.Cmd) error {
+					return errors.New("not a mountpoint")
+				})
+			}
 		})
 
-		Context("and the hierarchy is not mounted", func() {
+		It("succeeds", func() {
+			Expect(starter.Start()).To(Succeed())
+		})
+
+		It("mounts the hierarchies which are not already mounted", func() {
+			starter.Start()
+
+			Expect(runner).To(HaveExecutedSerially(fake_command_runner.CommandSpec{
+				Path: "mount",
+				Args: []string{"-n", "-t", "cgroup", "-o", "devices", "cgroup", path.Join(tmpDir, "cgroup", "devices")},
+			}))
+
+			Expect(runner).NotTo(HaveExecutedSerially(fake_command_runner.CommandSpec{
+				Path: "mount",
+				Args: []string{"-n", "-t", "cgroup", "-o", "memory", "cgroup", path.Join(tmpDir, "cgroup", "memory")},
+			}))
+
+			Expect(runner).To(HaveExecutedSerially(fake_command_runner.CommandSpec{
+				Path: "mount",
+				Args: []string{"-n", "-t", "cgroup", "-o", "cpu,cpuacct", "cgroup", path.Join(tmpDir, "cgroup", "cpu")},
+			}))
+
+			Expect(runner).To(HaveExecutedSerially(fake_command_runner.CommandSpec{
+				Path: "mount",
+				Args: []string{"-n", "-t", "cgroup", "-o", "cpu,cpuacct", "cgroup", path.Join(tmpDir, "cgroup", "cpuacct")},
+			}))
+		})
+
+		It("creates needed directories", func() {
+			starter.Start()
+			Expect(path.Join(tmpDir, "cgroup", "devices")).To(BeADirectory())
+		})
+
+		Context("when a subsystem is not yet mounted anywhere", func() {
 			BeforeEach(func() {
-				for _, notMounted := range []string{"devices", "cpu", "cpuacct"} {
-					runner.WhenRunning(fake_command_runner.CommandSpec{
-						Path: "mountpoint",
-						Args: []string{"-q", path.Join(tmpDir, "cgroup", notMounted)},
-					}, func(cmd *exec.Cmd) error {
-						return errors.New("not a mountpoint")
-					})
-				}
+				_, err := procCgroups.Write([]byte("freezer\t7\t1\t1\n"))
+				Expect(err).NotTo(HaveOccurred())
+
+				runner.WhenRunning(fake_command_runner.CommandSpec{
+					Path: "mountpoint",
+					Args: []string{"-q", path.Join(tmpDir, "cgroup", "freezer")},
+				}, func(cmd *exec.Cmd) error {
+					return errors.New("not a mountpoint")
+				})
 			})
 
-			It("mounts the hierarchies which are not mounted", func() {
+			It("mounts it as its own subsystem", func() {
 				starter.Start()
-				Expect(runner).To(HaveExecutedSerially(fake_command_runner.CommandSpec{
-					Path: "mount",
-					Args: []string{"-n", "-t", "cgroup", "-o", "devices", "cgroup", path.Join(tmpDir, "cgroup", "devices")},
-				}))
-
-				Expect(runner).NotTo(HaveExecutedSerially(fake_command_runner.CommandSpec{
-					Path: "mount",
-					Args: []string{"-n", "-t", "cgroup", "-o", "memory", "cgroup", path.Join(tmpDir, "cgroup", "memory")},
-				}))
 
 				Expect(runner).To(HaveExecutedSerially(fake_command_runner.CommandSpec{
 					Path: "mount",
-					Args: []string{"-n", "-t", "cgroup", "-o", "cpu,cpuacct", "cgroup", path.Join(tmpDir, "cgroup", "cpu")},
-				}))
-
-				Expect(runner).To(HaveExecutedSerially(fake_command_runner.CommandSpec{
-					Path: "mount",
-					Args: []string{"-n", "-t", "cgroup", "-o", "cpu,cpuacct", "cgroup", path.Join(tmpDir, "cgroup", "cpuacct")},
+					Args: []string{"-n", "-t", "cgroup", "-o", "freezer", "cgroup", path.Join(tmpDir, "cgroup", "freezer")},
 				}))
 			})
+		})
 
-			It("creates needed directories", func() {
+		Context("when a subsystem is disabled", func() {
+			BeforeEach(func() {
+				_, err := procCgroups.Write([]byte("freezer\t7\t1\t0\n"))
+				Expect(err).NotTo(HaveOccurred())
+
+				runner.WhenRunning(fake_command_runner.CommandSpec{
+					Path: "mountpoint",
+					Args: []string{"-q", path.Join(tmpDir, "cgroup", "freezer")},
+				}, func(cmd *exec.Cmd) error {
+					return errors.New("not a mountpoint")
+				})
+			})
+
+			It("mounts it as its own subsystem", func() {
 				starter.Start()
-				Expect(path.Join(tmpDir, "cgroup", "devices")).To(BeADirectory())
+
+				Expect(runner).ToNot(HaveExecutedSerially(fake_command_runner.CommandSpec{
+					Path: "mount",
+					Args: []string{"-n", "-t", "cgroup", "-o", "freezer", "cgroup", path.Join(tmpDir, "cgroup", "freezer")},
+				}))
 			})
+		})
+	})
+
+	Context("when /proc/cgroups contains malformed entries", func() {
+		BeforeEach(func() {
+			_, err := procCgroups.Write([]byte(
+				"#subsys_name\thierarchy\tnum_cgroups\tenabled\n" +
+					"devices\tA ONE AND A\t1\t1\n" +
+					"memory\tTWO AND A\t1\t1\n" +
+					"cpu\tTHREE AND A\t1\t1\n" +
+					"cpuacct\tFOUR\t1\t1\n",
+			))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = procSelfCgroups.Write([]byte(
+				"5:devices:/\n" +
+					"4:memory:/\n" +
+					"3:cpu,cpuacct:/\n",
+			))
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, notMounted := range []string{"devices", "cpu", "cpuacct"} {
+				runner.WhenRunning(fake_command_runner.CommandSpec{
+					Path: "mountpoint",
+					Args: []string{"-q", path.Join(tmpDir, "cgroup", notMounted)},
+				}, func(cmd *exec.Cmd) error {
+					return errors.New("not a mountpoint")
+				})
+			}
+		})
+
+		It("returns CgroupsFormatError", func() {
+			err := starter.Start()
+			Expect(err).To(Equal(rundmc.CgroupsFormatError{Content: "devices\tA ONE AND A\t1\t1"}))
+		})
+	})
+
+	Context("when /proc/cgroups is empty", func() {
+		BeforeEach(func() {
+			_, err := procCgroups.Write([]byte(""))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = procSelfCgroups.Write([]byte(
+				"5:devices:/\n" +
+					"4:memory:/\n" +
+					"3:cpu,cpuacct:/\n",
+			))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns CgroupsFormatError", func() {
+			err := starter.Start()
+			Expect(err).To(Equal(rundmc.CgroupsFormatError{Content: "(empty)"}))
+		})
+	})
+
+	Context("when /proc/cgroups contains an unknown header scheme", func() {
+		BeforeEach(func() {
+			_, err := procCgroups.Write([]byte(
+				"#subsys_name\tsome\tbogus\tcolumns\n" +
+					"devices\t1\t1\t1" +
+					"memory\t2\t1\t1" +
+					"cpu\t3\t1\t1" +
+					"cpuacct\t4\t1\t1",
+			))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = procSelfCgroups.Write([]byte(
+				"5:devices:/\n" +
+					"4:memory:/\n" +
+					"3:cpu,cpuacct:/\n",
+			))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns CgroupsFormatError", func() {
+			err := starter.Start()
+			Expect(err).To(Equal(rundmc.CgroupsFormatError{Content: "#subsys_name\tsome\tbogus\tcolumns"}))
 		})
 	})
 


### PR DESCRIPTION
* parse the expected header, bail if it's not what we expect
* fix skipping the second line of /proc/cgroups; this meant we were
  skipping a subsytem this whole time
* handle subsystems being disabled by skipping them
* handle subsystems that are enabled but not mounted anywhere by
  mounting them on their own