### PR TITLE
persist and report container grace time

### DIFF
--- a/gardener/container.go
+++ b/gardener/container.go
@@ -2,6 +2,7 @@ package gardener
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"time"
 
@@ -165,5 +166,5 @@ func (c *container) RemoveProperty(name string) error {
 }
 
 func (c *container) SetGraceTime(t time.Duration) error {
-	return nil
+	return c.propertyManager.Set(c.handle, GraceTimeKey, fmt.Sprintf("%d", t))
 }


### PR DESCRIPTION
This should satisfy https://www.pivotaltracker.com/story/show/116986065.

Haven't added a GQT yet as I'm not sure there's a great way to test this kind of thing without introducing either flakiness or slowness (plus the actual logic for that lives in `garden` anyway).