### PR TITLE
force 'mountpoint' to follow symlinks

### DIFF
--- a/rundmc/starter.go
+++ b/rundmc/starter.go
@@ -166,5 +166,7 @@ func (s *CgroupStarter) mountCgroup(logger lager.Logger, cgroupPath, subsystems 
 }
 
 func (s *CgroupStarter) isMountPoint(path string) bool {
-	return s.CommandRunner.Run(exec.Command("mountpoint", "-q", path)) == nil
+	// append trailing slash to force symlink traversal; symlinking e.g. 'cpu'
+	// to 'cpu,cpuacct' is common
+	return s.CommandRunner.Run(exec.Command("mountpoint", "-q", path+"/")) == nil
 }

--- a/rundmc/starter_test.go
+++ b/rundmc/starter_test.go
@@ -59,7 +59,7 @@ var _ = Describe("CgroupStarter", func() {
 		BeforeEach(func() {
 			runner.WhenRunning(fake_command_runner.CommandSpec{
 				Path: "mountpoint",
-				Args: []string{"-q", path.Join(tmpDir, "cgroup")},
+				Args: []string{"-q", path.Join(tmpDir, "cgroup") + "/"},
 			}, func(cmd *exec.Cmd) error {
 				return errors.New("not a mountpoint")
 			})
@@ -105,7 +105,7 @@ var _ = Describe("CgroupStarter", func() {
 			for _, notMounted := range []string{"devices", "cpu", "cpuacct"} {
 				runner.WhenRunning(fake_command_runner.CommandSpec{
 					Path: "mountpoint",
-					Args: []string{"-q", path.Join(tmpDir, "cgroup", notMounted)},
+					Args: []string{"-q", path.Join(tmpDir, "cgroup", notMounted) + "/"},
 				}, func(cmd *exec.Cmd) error {
 					return errors.New("not a mountpoint")
 				})
@@ -152,7 +152,7 @@ var _ = Describe("CgroupStarter", func() {
 
 				runner.WhenRunning(fake_command_runner.CommandSpec{
 					Path: "mountpoint",
-					Args: []string{"-q", path.Join(tmpDir, "cgroup", "freezer")},
+					Args: []string{"-q", path.Join(tmpDir, "cgroup", "freezer") + "/"},
 				}, func(cmd *exec.Cmd) error {
 					return errors.New("not a mountpoint")
 				})
@@ -175,7 +175,7 @@ var _ = Describe("CgroupStarter", func() {
 
 				runner.WhenRunning(fake_command_runner.CommandSpec{
 					Path: "mountpoint",
-					Args: []string{"-q", path.Join(tmpDir, "cgroup", "freezer")},
+					Args: []string{"-q", path.Join(tmpDir, "cgroup", "freezer") + "/"},
 				}, func(cmd *exec.Cmd) error {
 					return errors.New("not a mountpoint")
 				})
@@ -213,7 +213,7 @@ var _ = Describe("CgroupStarter", func() {
 			for _, notMounted := range []string{"devices", "cpu", "cpuacct"} {
 				runner.WhenRunning(fake_command_runner.CommandSpec{
 					Path: "mountpoint",
-					Args: []string{"-q", path.Join(tmpDir, "cgroup", notMounted)},
+					Args: []string{"-q", path.Join(tmpDir, "cgroup", notMounted) + "/"},
 				}, func(cmd *exec.Cmd) error {
 					return errors.New("not a mountpoint")
 				})


### PR DESCRIPTION
this fixes detection of already-mounted cgroups in the case where there
are symlinks under `/sys/fs/cgroup`, e.g.:

    drwxr-xr-x 2 root root  0 Apr 25 16:50 blkio
    lrwxrwxrwx 1 root root 11 Apr 25 16:47 cpu -> cpu,cpuacct
    drwxr-xr-x 2 root root  0 Apr 25 16:50 cpu,cpuacct
    lrwxrwxrwx 1 root root 11 Apr 25 16:47 cpuacct -> cpu,cpuacct
    drwxr-xr-x 2 root root  0 Apr 25 16:50 cpuset
    drwxr-xr-x 2 root root  0 Apr 25 16:50 devices
    drwxr-xr-x 2 root root  0 Apr 25 16:50 freezer
    drwxr-xr-x 2 root root  0 Apr 25 16:50 hugetlb
    drwxr-xr-x 2 root root  0 Apr 25 16:50 memory
    lrwxrwxrwx 1 root root 16 Apr 25 16:47 net_cls -> net_cls,net_prio
    drwxr-xr-x 2 root root  0 Apr 25 16:50 net_cls,net_prio
    lrwxrwxrwx 1 root root 16 Apr 25 16:47 net_prio -> net_cls,net_prio
    drwxr-xr-x 2 root root  0 Apr 25 16:50 perf_event
    drwxr-xr-x 2 root root  0 Apr 25 16:50 systemd

some versions of `mountpoint` (util-linux 2.27.1 in my case)
automatically follow symlinks, but others do not, unless a trailing
slash is added to the end of the path