### PR TITLE
Propagate network properties to network plugins

### DIFF
--- a/gardener/fakes/fake_networker.go
+++ b/gardener/fakes/fake_networker.go
@@ -10,13 +10,11 @@ import (
 )
 
 type FakeNetworker struct {
-	HooksStub        func(log lager.Logger, handle, spec, externalSpec string) ([]gardener.Hooks, error)
+	HooksStub        func(log lager.Logger, containerSpec garden.ContainerSpec) ([]gardener.Hooks, error)
 	hooksMutex       sync.RWMutex
 	hooksArgsForCall []struct {
-		log          lager.Logger
-		handle       string
-		spec         string
-		externalSpec string
+		log           lager.Logger
+		containerSpec garden.ContainerSpec
 	}
 	hooksReturns struct {
 		result1 []gardener.Hooks
@@ -71,17 +69,15 @@ type FakeNetworker struct {
 	}
 }
 
-func (fake *FakeNetworker) Hooks(log lager.Logger, handle string, spec string, externalSpec string) ([]gardener.Hooks, error) {
+func (fake *FakeNetworker) Hooks(log lager.Logger, containerSpec garden.ContainerSpec) ([]gardener.Hooks, error) {
 	fake.hooksMutex.Lock()
 	fake.hooksArgsForCall = append(fake.hooksArgsForCall, struct {
-		log          lager.Logger
-		handle       string
-		spec         string
-		externalSpec string
-	}{log, handle, spec, externalSpec})
+		log           lager.Logger
+		containerSpec garden.ContainerSpec
+	}{log, containerSpec})
 	fake.hooksMutex.Unlock()
 	if fake.HooksStub != nil {
-		return fake.HooksStub(log, handle, spec, externalSpec)
+		return fake.HooksStub(log, containerSpec)
 	} else {
 		return fake.hooksReturns.result1, fake.hooksReturns.result2
 	}
@@ -93,10 +89,10 @@ func (fake *FakeNetworker) HooksCallCount() int {
 	return len(fake.hooksArgsForCall)
 }
 
-func (fake *FakeNetworker) HooksArgsForCall(i int) (lager.Logger, string, string, string) {
+func (fake *FakeNetworker) HooksArgsForCall(i int) (lager.Logger, garden.ContainerSpec) {
 	fake.hooksMutex.RLock()
 	defer fake.hooksMutex.RUnlock()
-	return fake.hooksArgsForCall[i].log, fake.hooksArgsForCall[i].handle, fake.hooksArgsForCall[i].spec, fake.hooksArgsForCall[i].externalSpec
+	return fake.hooksArgsForCall[i].log, fake.hooksArgsForCall[i].containerSpec
 }
 
 func (fake *FakeNetworker) HooksReturns(result1 []gardener.Hooks, result2 error) {

--- a/gardener/gardener.go
+++ b/gardener/gardener.go
@@ -52,7 +52,7 @@ type Containerizer interface {
 }
 
 type Networker interface {
-	Hooks(log lager.Logger, handle, spec, externalSpec string) ([]Hooks, error)
+	Hooks(log lager.Logger, containerSpec garden.ContainerSpec) ([]Hooks, error)
 	Capacity() uint64
 	Destroy(log lager.Logger, handle string) error
 	NetIn(log lager.Logger, handle string, hostPort, containerPort uint32) (uint32, uint32, error)
@@ -208,7 +208,7 @@ func (g *Gardener) Create(spec garden.ContainerSpec) (ctr garden.Container, err 
 		}
 	}()
 
-	networkHooks, err := g.Networker.Hooks(log, spec.Handle, spec.Network, spec.Properties[ExternalNetworkSpecKey])
+	networkHooks, err := g.Networker.Hooks(log, spec)
 	if err != nil {
 		return nil, err
 	}

--- a/gardener/gardener.go
+++ b/gardener/gardener.go
@@ -26,7 +26,6 @@ const BridgeIPKey = "garden.network.host-ip"
 const ExternalIPKey = "garden.network.external-ip"
 const MappedPortsKey = "garden.network.mapped-ports"
 const GraceTimeKey = "garden.grace-time"
-const ExternalNetworkSpecKey = "garden.external.network-spec"
 
 const RawRootFSScheme = "raw"
 

--- a/gardener/gardener_test.go
+++ b/gardener/gardener_test.go
@@ -110,16 +110,16 @@ var _ = Describe("Gardener", func() {
 
 		Context("when the networker provides hooks", func() {
 			BeforeEach(func() {
-				networker.HooksStub = func(_ lager.Logger, handle, spec, externalSpec string) ([]gardener.Hooks, error) {
+				networker.HooksStub = func(_ lager.Logger, containerSpec garden.ContainerSpec) ([]gardener.Hooks, error) {
 					return []gardener.Hooks{
 						gardener.Hooks{
 							Prestart: gardener.Hook{
 								Path: "/path/to/banana/exe",
-								Args: []string{"--handle", handle, "--spec", spec},
+								Args: []string{"--handle", containerSpec.Handle, "--spec", containerSpec.Network},
 							},
 							Poststop: gardener.Hook{
 								Path: "/path/to/bananana/exe",
-								Args: []string{"--handle", handle, "--spec", spec},
+								Args: []string{"--handle", containerSpec.Handle, "--spec", containerSpec.Network},
 							},
 						},
 					}, nil

--- a/kawasaki/composite_networker.go
+++ b/kawasaki/composite_networker.go
@@ -1,6 +1,7 @@
 package kawasaki
 
 import (
+	"github.com/cloudfoundry-incubator/garden"
 	"github.com/cloudfoundry-incubator/guardian/gardener"
 	"github.com/pivotal-golang/lager"
 )
@@ -10,14 +11,14 @@ type CompositeNetworker struct {
 	ExtraHooks []NetworkHooker
 }
 
-func (c *CompositeNetworker) Hooks(log lager.Logger, handle, spec, externalNetworkSpec string) ([]gardener.Hooks, error) {
-	hooks, err := c.Networker.Hooks(log, handle, spec, externalNetworkSpec)
+func (c *CompositeNetworker) Hooks(log lager.Logger, containerSpec garden.ContainerSpec) ([]gardener.Hooks, error) {
+	hooks, err := c.Networker.Hooks(log, containerSpec)
 	if err != nil {
 		return []gardener.Hooks{}, err
 	}
 
 	for _, hooker := range c.ExtraHooks {
-		hook, err := hooker.Hooks(log, handle, spec, externalNetworkSpec)
+		hook, err := hooker.Hooks(log, containerSpec)
 		if err != nil {
 			return []gardener.Hooks{}, err
 		}

--- a/kawasaki/fakes/fake_network_hooker.go
+++ b/kawasaki/fakes/fake_network_hooker.go
@@ -4,19 +4,18 @@ package fakes
 import (
 	"sync"
 
+	"github.com/cloudfoundry-incubator/garden"
 	"github.com/cloudfoundry-incubator/guardian/gardener"
 	"github.com/cloudfoundry-incubator/guardian/kawasaki"
 	"github.com/pivotal-golang/lager"
 )
 
 type FakeNetworkHooker struct {
-	HooksStub        func(log lager.Logger, handle, spec, externalNetworkSpec string) (gardener.Hooks, error)
+	HooksStub        func(log lager.Logger, containerSpec garden.ContainerSpec) (gardener.Hooks, error)
 	hooksMutex       sync.RWMutex
 	hooksArgsForCall []struct {
-		log                 lager.Logger
-		handle              string
-		spec                string
-		externalNetworkSpec string
+		log           lager.Logger
+		containerSpec garden.ContainerSpec
 	}
 	hooksReturns struct {
 		result1 gardener.Hooks
@@ -24,17 +23,15 @@ type FakeNetworkHooker struct {
 	}
 }
 
-func (fake *FakeNetworkHooker) Hooks(log lager.Logger, handle string, spec string, externalNetworkSpec string) (gardener.Hooks, error) {
+func (fake *FakeNetworkHooker) Hooks(log lager.Logger, containerSpec garden.ContainerSpec) (gardener.Hooks, error) {
 	fake.hooksMutex.Lock()
 	fake.hooksArgsForCall = append(fake.hooksArgsForCall, struct {
-		log                 lager.Logger
-		handle              string
-		spec                string
-		externalNetworkSpec string
-	}{log, handle, spec, externalNetworkSpec})
+		log           lager.Logger
+		containerSpec garden.ContainerSpec
+	}{log, containerSpec})
 	fake.hooksMutex.Unlock()
 	if fake.HooksStub != nil {
-		return fake.HooksStub(log, handle, spec, externalNetworkSpec)
+		return fake.HooksStub(log, containerSpec)
 	} else {
 		return fake.hooksReturns.result1, fake.hooksReturns.result2
 	}
@@ -46,10 +43,10 @@ func (fake *FakeNetworkHooker) HooksCallCount() int {
 	return len(fake.hooksArgsForCall)
 }
 
-func (fake *FakeNetworkHooker) HooksArgsForCall(i int) (lager.Logger, string, string, string) {
+func (fake *FakeNetworkHooker) HooksArgsForCall(i int) (lager.Logger, garden.ContainerSpec) {
 	fake.hooksMutex.RLock()
 	defer fake.hooksMutex.RUnlock()
-	return fake.hooksArgsForCall[i].log, fake.hooksArgsForCall[i].handle, fake.hooksArgsForCall[i].spec, fake.hooksArgsForCall[i].externalNetworkSpec
+	return fake.hooksArgsForCall[i].log, fake.hooksArgsForCall[i].containerSpec
 }
 
 func (fake *FakeNetworkHooker) HooksReturns(result1 gardener.Hooks, result2 error) {

--- a/kawasaki/fakes/fake_networker.go
+++ b/kawasaki/fakes/fake_networker.go
@@ -17,13 +17,11 @@ type FakeNetworker struct {
 	capacityReturns     struct {
 		result1 uint64
 	}
-	HooksStub        func(log lager.Logger, handle, spec, externalNetworkSpec string) ([]gardener.Hooks, error)
+	HooksStub        func(log lager.Logger, containerSpec garden.ContainerSpec) ([]gardener.Hooks, error)
 	hooksMutex       sync.RWMutex
 	hooksArgsForCall []struct {
-		log                 lager.Logger
-		handle              string
-		spec                string
-		externalNetworkSpec string
+		log           lager.Logger
+		containerSpec garden.ContainerSpec
 	}
 	hooksReturns struct {
 		result1 []gardener.Hooks
@@ -96,17 +94,15 @@ func (fake *FakeNetworker) CapacityReturns(result1 uint64) {
 	}{result1}
 }
 
-func (fake *FakeNetworker) Hooks(log lager.Logger, handle string, spec string, externalNetworkSpec string) ([]gardener.Hooks, error) {
+func (fake *FakeNetworker) Hooks(log lager.Logger, containerSpec garden.ContainerSpec) ([]gardener.Hooks, error) {
 	fake.hooksMutex.Lock()
 	fake.hooksArgsForCall = append(fake.hooksArgsForCall, struct {
-		log                 lager.Logger
-		handle              string
-		spec                string
-		externalNetworkSpec string
-	}{log, handle, spec, externalNetworkSpec})
+		log           lager.Logger
+		containerSpec garden.ContainerSpec
+	}{log, containerSpec})
 	fake.hooksMutex.Unlock()
 	if fake.HooksStub != nil {
-		return fake.HooksStub(log, handle, spec, externalNetworkSpec)
+		return fake.HooksStub(log, containerSpec)
 	} else {
 		return fake.hooksReturns.result1, fake.hooksReturns.result2
 	}
@@ -118,10 +114,10 @@ func (fake *FakeNetworker) HooksCallCount() int {
 	return len(fake.hooksArgsForCall)
 }
 
-func (fake *FakeNetworker) HooksArgsForCall(i int) (lager.Logger, string, string, string) {
+func (fake *FakeNetworker) HooksArgsForCall(i int) (lager.Logger, garden.ContainerSpec) {
 	fake.hooksMutex.RLock()
 	defer fake.hooksMutex.RUnlock()
-	return fake.hooksArgsForCall[i].log, fake.hooksArgsForCall[i].handle, fake.hooksArgsForCall[i].spec, fake.hooksArgsForCall[i].externalNetworkSpec
+	return fake.hooksArgsForCall[i].log, fake.hooksArgsForCall[i].containerSpec
 }
 
 func (fake *FakeNetworker) HooksReturns(result1 []gardener.Hooks, result2 error) {

--- a/kawasaki/networker_test.go
+++ b/kawasaki/networker_test.go
@@ -49,9 +49,6 @@ var _ = Describe("Networker", func() {
 		containerSpec = garden.ContainerSpec{
 			Handle:  "some-handle",
 			Network: "1.2.3.4/30",
-			Properties: garden.Properties{
-				gardener.ExternalNetworkSpecKey: "external-network-spec",
-			},
 		}
 
 		logger = lagertest.NewTestLogger("test")

--- a/netplugin/plugin.go
+++ b/netplugin/plugin.go
@@ -1,6 +1,7 @@
 package netplugin
 
 import (
+	"github.com/cloudfoundry-incubator/garden"
 	"github.com/cloudfoundry-incubator/guardian/gardener"
 	"github.com/pivotal-golang/lager"
 )
@@ -17,8 +18,13 @@ func New(path string, extraArg ...string) *Plugin {
 	}
 }
 
-func (p Plugin) Hooks(log lager.Logger, handle, spec, externalSpec string) (gardener.Hooks, error) {
+func (p Plugin) Hooks(log lager.Logger, containerSpec garden.ContainerSpec) (gardener.Hooks, error) {
 	pathAndExtraArgs := append([]string{p.path}, p.extraArg...)
+
+	handle := containerSpec.Handle
+	spec := containerSpec.Network
+	externalSpec := containerSpec.Properties[gardener.ExternalNetworkSpecKey]
+
 	networkPluginFlags := []string{"--handle", handle, "--network", spec, "--external-network", externalSpec}
 
 	upArgs := append(pathAndExtraArgs, "--action", "up")


### PR DESCRIPTION
`ContainerSpec` properties which begin with the string `network.` are provided to the external network plugin.

It is actually kind of flexible: since the `Networker.Hooks()` takes a `ContainerSpec`, it has some freedom to change what sort of data it passes to the hooks, and how.

- @rosenhouse & @sykesm 

